### PR TITLE
Added the information about the server being down.

### DIFF
--- a/info/join.md
+++ b/info/join.md
@@ -4,6 +4,9 @@ You can join the network via KiwiIRC or IRCCloud (web clients) or your own choic
 
 We recommend joining with `irc.chew.chat`, to join a random server. Below are direct IPs to each server.
 
+
+#### Due to scaleway being itself (unpredictable and messy, but inexpensive so worth it [much like Spectrum]) I have created a fallback server forked from kitty.chew.chat. Both kitty.chew.chat and cah.chew.chat will be down for an unknown amount of time between right now and the 6th. The fallback server is on Digital Ocean, only temporary. If you are not connected to `irc.chew.chat`, your connection will be lost for an unknown amount of time. So please connect there. Your client should simply reconnect to `irc.chew.chat` or a different fallback server. Thanks! If you're still confused, feel free to stop by [#help](https://www.irccloud.com/invite?channel=%23help&hostname=irc.chew.chat&port=6697&ssl=1).
+
 IP              | Status  | Port | SSL Port | Server Maintainer
 --------------- | ------- | ---- | -------- | -----------------
 kitty.chew.chat | Active! | 6667 | 6697     | Chew


### PR DESCRIPTION
#### Due to scaleway being itself (unpredictable and messy, but inexpensive so worth it [much like Spectrum]) I have created a fallback server forked from kitty.chew.chat. Both kitty.chew.chat and cah.chew.chat will be down for an unknown amount of time between right now and the 6th. The fallback server is on Digital Ocean, only temporary. If you are not connected to `irc.chew.chat`, your connection will be lost for an unknown amount of time. So please connect there. Your client should simply reconnect to `irc.chew.chat` or a different fallback server. Thanks! If you're still confused, feel free to stop by [#help](https://www.irccloud.com/invite?channel=%23help&hostname=irc.chew.chat&port=6697&ssl=1).